### PR TITLE
Fix path to main in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.3",
   "description": "Easily load assets into your Phaser game using a simple manifest",
   "author": "matt colman <matt@mattcolman.com>",
-  "main": "index.js",
+  "main": "src/index.js",
   "scripts": {
     "start": "npm run run-demo",
     "compile": "babel --presets es2015 -d lib/ src/",


### PR DESCRIPTION
The path is currently pointing to `index.js`, but it should actually be `src/index.js`. Without this fix, you have to do the following to import the plugin:

`import ManifestLoader from 'phaser-manifest-loader/src';`

instead of:

`import ManifestLoader from 'phaser-manifest-loader';`